### PR TITLE
feat: respect no-transform header value

### DIFF
--- a/vulcain.go
+++ b/vulcain.go
@@ -153,7 +153,7 @@ func (v *Vulcain) IsValidRequest(req *http.Request) bool {
 
 // IsValidResponse checks if Apply will be able to deal with this response.
 func (v *Vulcain) IsValidResponse(req *http.Request, responseStatus int, responseHeaders http.Header) bool {
-	// Not a success,marked as no-transform or not JSON: don't modify the response
+	// Not a success, marked as no-transform or not JSON: don't modify the response
 	if responseStatus < 200 ||
 		responseStatus > 300 ||
 		!jsonRe.MatchString(responseHeaders.Get("Content-Type")) ||

--- a/vulcain.go
+++ b/vulcain.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	jsonRe   = regexp.MustCompile(`(?i)\bjson\b`)
-	preferRe = regexp.MustCompile(`\s*selector="?json-pointer"?`)
+	jsonRe        = regexp.MustCompile(`(?i)\bjson\b`)
+	preferRe      = regexp.MustCompile(`\s*selector="?json-pointer"?`)
+	notransformRe = regexp.MustCompile(`\bno-transform\b`)
 )
 
 // Option instances allow to configure the library
@@ -152,10 +153,11 @@ func (v *Vulcain) IsValidRequest(req *http.Request) bool {
 
 // IsValidResponse checks if Apply will be able to deal with this response.
 func (v *Vulcain) IsValidResponse(req *http.Request, responseStatus int, responseHeaders http.Header) bool {
-	// Not a success, or not JSON: don't modify the response
+	// Not a success,marked as no-transform or not JSON: don't modify the response
 	if responseStatus < 200 ||
 		responseStatus > 300 ||
-		!jsonRe.MatchString(responseHeaders.Get("Content-Type")) {
+		!jsonRe.MatchString(responseHeaders.Get("Content-Type")) ||
+		notransformRe.MatchString(responseHeaders.Get("Cache-Control")) {
 
 		return false
 	}

--- a/vulcain_test.go
+++ b/vulcain_test.go
@@ -46,7 +46,7 @@ func TestIsValidResponse(t *testing.T) {
 	assert.False(t, v.IsValidResponse(
 		&http.Request{URL: &url.URL{}},
 		200,
-		http.Header{"Content-Type": []string{"text/xml"}},
+		http.Header{"Content-Type": []string{"text/xml"}, "Cache-Control": []string{"no-transform"}},
 	))
 
 	assert.False(t, v.IsValidResponse(
@@ -65,6 +65,15 @@ func TestIsValidResponse(t *testing.T) {
 		},
 		500,
 		http.Header{"Content-Type": []string{"application/json"}},
+	))
+
+	assert.False(t, v.IsValidResponse(
+		&http.Request{
+			URL:    &url.URL{},
+			Header: http.Header{"Preload": []string{`"/foo"`}, "Prefer": []string{"selector=json-pointer"}},
+		},
+		200,
+		http.Header{"Cache-Control": []string{"no-transform"}},
 	))
 
 	assert.True(t, v.IsValidResponse(


### PR DESCRIPTION
With this , vulcan won't modify response if the `no-transform` header value is present.
Also, test for this behaviour is added in this PR.

Closes #66 