### PR TITLE
fix: clarify order the directive

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -19,6 +19,7 @@ import (
 func init() {
 	caddy.RegisterModule(Vulcain{})
 	httpcaddyfile.RegisterHandlerDirective("vulcain", parseCaddyfile)
+	httpcaddyfile.RegisterDirectiveOrder("vulcain", "after", "reverse_proxy")
 	httpcaddyfile.RegisterDirectiveOrder("vulcain", "before", "request_header")
 }
 


### PR DESCRIPTION
Fixes #161

Extends the default ordering to what FrankenPHP had before https://github.com/php/frankenphp/pull/832.