### PR TITLE
fix: skip URL rewriting for non-relation field values

### DIFF
--- a/fixtures/api/jsonld.go
+++ b/fixtures/api/jsonld.go
@@ -73,6 +73,7 @@ func (h *JSONLDHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	"@id": `+string(encodedURI)+`,
 	"title": "Book 1",
 	"description": "A good book",
+	"year": 2019,
 	"author": "/authors/1.jsonld",
 	"related": "/books/99.jsonld"
 	}`); err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -202,6 +202,28 @@ func TestFieldsQuery(t *testing.T) {
 	assert.Equal(t, `{"@id":"/books.jsonld"}`, string(b))
 }
 
+func TestFieldsQueryDoesNotEncodePlainValues(t *testing.T) {
+	upstream, gateway := createServers(-1, false)
+	defer upstream.Close()
+	defer gateway.Close()
+
+	resp, _ := http.Get(gateway.URL + `/books/1.jsonld?fields="/title","/description"`)
+	b, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, `{"title":"Book 1","description":"A good book"}`, string(b))
+}
+
+func TestFieldsQueryPreservesNumberType(t *testing.T) {
+	upstream, gateway := createServers(-1, false)
+	defer upstream.Close()
+	defer gateway.Close()
+
+	resp, _ := http.Get(gateway.URL + `/books/1.jsonld?fields="/year"`)
+	b, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, `{"year":2019}`, string(b))
+}
+
 func TestFieldsHeader(t *testing.T) {
 	upstream, gateway := createServers(-1, false)
 	defer upstream.Close()

--- a/vulcain.go
+++ b/vulcain.go
@@ -212,6 +212,14 @@ func (v *Vulcain) Apply(req *http.Request, rw http.ResponseWriter, responseBody 
 		oaRouteTested, usePreloadLinks bool
 	)
 	newBody := v.traverseJSON(currentBody, tree, len(f) > 0, func(n *node, val string) string {
+		// A pure field projection (a "fields" leaf with no relation to push and no child
+		// selector to propagate) is not a relation: leave its value untouched. Routing it
+		// through the URL machinery below would percent-encode plain strings and coerce
+		// numbers to strings (https://github.com/dunglas/vulcain/issues/96).
+		if !n.preload && !n.hasChildren(preload) && !n.hasChildren(fields) {
+			return ""
+		}
+
 		var (
 			u        *url.URL
 			useOA    bool


### PR DESCRIPTION
## Problem

Fixes #96.

A `?fields=` query that selects scalar fields returns corrupted values:

- plain strings are percent-encoded — `"Book 1"` → `"Book%201"`, `"Roland Garros 2019"` → `"Roland%20Garros%202019"`;
- numbers are coerced to strings — `2019` → `"2019"` (a float is even truncated).

The bug only affects the **query** form (`?fields=`), not the **header** form (`Fields:`), which is why it surfaced with parametrized queries.

## Root cause

In `Apply`, the relation handler is invoked for **every scalar leaf** of the document — including pure field projections that are not relations. Each such value is parsed with `url.Parse` and re-serialized with `url.URL.String()`, which percent-encodes the path; numbers are additionally re-marshalled from a string. Only the query form rewrites the body (`urlRewriter` + `u.String()`), so only it exposes the corruption.

## Fix

Guard the handler so a node that is **not a relation** — no relation to push (`preload`) and no child selector to propagate — is returned untouched, before any URL machinery runs:

```go
if !n.preload && !n.hasChildren(preload) && !n.hasChildren(fields) {
    return ""
}
```

The query-vs-header propagation logic is left intact; the guard only restores the precondition that block always assumed — that it operates on relations.

## Efficiency

Because the guard short-circuits **before** `url.Parse`, the query re-encoding and the `json.Marshal`, it also removes wasted work on the fields path. Benchmark on a `?fields=` query selecting 7 scalar fields (5 runs, Go 1.26):

| Metric | Before | After | Δ |
|---|---|---|---|
| Time | ~17,600 ns/op | ~12,785 ns/op | **−27%** |
| Memory | 14,220 B/op | 11,512 B/op | **−19%** |
| Allocations | 175 allocs/op | 122 allocs/op | **−30%** |

<details>
<summary>Benchmark used</summary>

```go
func BenchmarkApplyFieldsQuery(b *testing.B) {
	v := New()
	body := []byte(`{"a":"Roland Garros 2019","b":"Internationaux de France de tennis","c":"A good long description here","d":"Some more textual content","e":"Yet another value with spaces","f":2019,"g":42,"h":"short","i":"value","j":"tail"}`)
	headers := http.Header{"Content-Type": []string{"application/json"}}

	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		req := httptest.NewRequest("GET", "/", nil)
		req.URL.RawQuery = `fields="/a","/b","/c","/d","/e","/f","/g"`
		rw := httptest.NewRecorder()
		if _, err := v.Apply(req, rw, bytes.NewReader(body), headers.Clone()); err != nil {
			b.Fatal(err)
		}
	}
}
```
</details>

## Tests

Two regression tests added in `server_test.go` (a numeric `year` field was added to the JSON-LD fixture to cover type preservation):

- `TestFieldsQueryDoesNotEncodePlainValues` — `"Book 1"` stays `"Book 1"`;
- `TestFieldsQueryPreservesNumberType` — `2019` stays a JSON number.
